### PR TITLE
Increase memory allocation for PCA on large data

### DIFF
--- a/rp_bin/pcaer_20
+++ b/rp_bin/pcaer_20
@@ -2052,8 +2052,6 @@ unless (-e "$bfile_menv.mds") {
 		    $sjaweek = 1;
 		}
 		if ($n_noov > 60000) {
-		    $sjamem = 10000;
-		} elsif ($n_noov > 40000) {
 		    $sjamem = 8000;
 		} else {
 		    $sjamem = 6000;


### PR DESCRIPTION
A small edit to increase the specified memory requirements for epca step running PCA with large datasets (N>60k). 

Made this edit after pcaer_20 failed when it hit the current 6GB memory ceiling while trying to run 67k individuals and 63k SNPs. FastPCA's pre-print benchmarks and additional testing suggest 6GB should cover most situations, but this adds some breathing room and resolves the failure in the N=67k dataset.

Further testing could probably refine this - 6G is almost certainly overkill at smaller sample sizes and I have a hunch that the memory performance is also shifting between Eigensoft versions - but for now this small bump is probably a useful change.
