### PR TITLE
config entry to make scripts run in serial mode 

### DIFF
--- a/rp_bin/clump_nav3
+++ b/rp_bin/clump_nav3
@@ -23,6 +23,7 @@ my $qloc = &trans("queue");
 #my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
+my $serial = &trans("serial") || 0;
 
 
 #######################################
@@ -102,7 +103,7 @@ GetOptions( "outname=s"=> \$outname,
 	    "det=i"=> \$detformat,
 
 	    "force1"=> \my $force1,
-	    "serial"=> \my $serial,
+	    "serial"=>  $serial,
 	    "sepa=i"=> \$sepa,
 
 	    "noclean"=> \my $noclean,

--- a/rp_bin/clump_nav3
+++ b/rp_bin/clump_nav3
@@ -23,7 +23,7 @@ my $qloc = &trans("queue");
 #my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 #######################################

--- a/rp_bin/impute_dirsub
+++ b/rp_bin/impute_dirsub
@@ -155,7 +155,7 @@ my $i2loc = &trans("i2loc");
 my $liloc = &trans("liloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 ###############################################

--- a/rp_bin/impute_dirsub
+++ b/rp_bin/impute_dirsub
@@ -155,6 +155,7 @@ my $i2loc = &trans("i2loc");
 my $liloc = &trans("liloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
+my $serial = &trans("serial") || 0;
 
 
 ###############################################
@@ -511,7 +512,7 @@ GetOptions(
     "triset=s"=> \my $trioset_file,
 
     "help"=> \my $help,
-    "serial"=> \my $serial,
+    "serial"=>  $serial,
     "sepa=i"=> \$sepa,
 
     "sleep=i"=> \my $sleep_sw,

--- a/rp_bin/pcaer
+++ b/rp_bin/pcaer
@@ -23,7 +23,7 @@ my $qloc = &trans("queue");
 my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 #######################################
 ## v12: with pops as reference

--- a/rp_bin/pcaer
+++ b/rp_bin/pcaer
@@ -23,6 +23,7 @@ my $qloc = &trans("queue");
 my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
+my $serial = &trans("serial") || 0;
 
 #######################################
 ## v12: with pops as reference
@@ -168,7 +169,7 @@ my $sepa = 1;
 use Getopt::Long;
 GetOptions( "out=s"=> \$outname,
 	    "help"=> \my $help,
-            "serial"=> \my $serial,
+            "serial"=>  $serial,
             "sleep=i"=> \my $sleep_sw,
 
 	    "trio"=> \my $trio,

--- a/rp_bin/postimp_navi
+++ b/rp_bin/postimp_navi
@@ -174,7 +174,7 @@ my $qloc = &trans("queue");
 my $i2loc = &trans("i2loc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 #exit;

--- a/rp_bin/postimp_navi
+++ b/rp_bin/postimp_navi
@@ -174,6 +174,7 @@ my $qloc = &trans("queue");
 my $i2loc = &trans("i2loc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
+my $serial = &trans("serial") || 0;
 
 
 #exit;
@@ -359,7 +360,7 @@ GetOptions(
     "allsw"=> \my $allsw,
     "cox"=> \my $cox,
     "outname=s"=> \my $outname,
-    "serial"=> \my $serial,
+    "serial"=>  $serial,
     "sepa=i"=> \$sepa,
 
     "sleep=i"=> \my $sleep_sw,

--- a/rp_bin/preimp_dir
+++ b/rp_bin/preimp_dir
@@ -38,7 +38,7 @@ my $qloc = &trans("queue");
 my $init = &trans("init");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 my $mind=0.02; # per ID	

--- a/rp_bin/preimp_dir
+++ b/rp_bin/preimp_dir
@@ -38,6 +38,7 @@ my $qloc = &trans("queue");
 my $init = &trans("init");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
+my $serial = &trans("serial") || 0;
 
 
 my $mind=0.02; # per ID	
@@ -133,7 +134,7 @@ use Getopt::Long;
 GetOptions( 
 
     "trio"=> \my $trio,
-    "serial"=> \my $serial,
+    "serial"=> $serial,
     "sepa=i"=> \$sepa,
 
     "sleep=i"=> \my $sleep_sw,

--- a/rp_bin/refdir_navi
+++ b/rp_bin/refdir_navi
@@ -99,6 +99,7 @@ my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
 my $bcrloc = &trans("bcrloc");
+my $serial = &trans("serial") || 0;
 
 #######################################
 
@@ -186,7 +187,7 @@ GetOptions(
     "qheadd=i"=> \$q16_head,
     "mac_th=i"=> \$mac_th,
     "walltimeplus=i"=> \$walltimeplus,
-    "serial"=> \my $serial,
+    "serial"=>  $serial,
     "sepa=i"=> \$sepa,
     
     );

--- a/rp_bin/refdir_navi
+++ b/rp_bin/refdir_navi
@@ -99,7 +99,7 @@ my $hmloc = &trans("hmloc");
 my $email = &trans("email");
 my $loloc = &trans("loloc");
 my $bcrloc = &trans("bcrloc");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 #######################################
 

--- a/rp_bin/rp_config
+++ b/rp_bin/rp_config
@@ -119,6 +119,7 @@ rp_logfiles
 ---- jobarray and queueing parameters: 
 ----------------------------------------
 ----------------------------------------
+serial 0
 batch_jobcommand                                 
 batch_memory_request                             
 batch_walltime                                   

--- a/rp_bin/rp_test_navi
+++ b/rp_bin/rp_test_navi
@@ -31,7 +31,7 @@ my $force1 = 0;
 my $outname = "test";
 my $job_bn_th = 1000;
 my $sepa = 1;
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 #######################################

--- a/rp_bin/rp_test_navi
+++ b/rp_bin/rp_test_navi
@@ -28,10 +28,10 @@ print "$rp_header\n";
 my $loloc = &trans("loloc");
 my $email = &trans("email");
 my $force1 = 0;
-my $serial = 0;
 my $outname = "test";
 my $job_bn_th = 1000;
 my $sepa = 1;
+my $serial = &trans("serial") || 0;
 
 
 #######################################
@@ -51,7 +51,7 @@ my $walltime = 4;
 use Getopt::Long;
 GetOptions( 
     "help"=> \my $help,
-    "serial"=> \my $serial,
+    "serial"=>  $serial,
     "sepa=i"=> \$sepa,
     "noldsc"=> \my $noldsc,
     

--- a/rp_bin/tarse_navi2
+++ b/rp_bin/tarse_navi2
@@ -29,7 +29,7 @@ my $qloc = &trans("queue");
 my $hmloc = &trans("hmloc");
 my $loloc = &trans("loloc");
 my $email = &trans("email");
-
+my $serial = &trans("serial") || 0;
 
 
 
@@ -65,7 +65,7 @@ GetOptions(
     "target=s"=> \$target,
     "password=s"=> \$password,
 
-        "serial"=> \my $serial,
+        "serial"=>  $serial,
     "force1"=> \my $force1,
     "sjamem_incr=i"=> \$sjamem_incr,
     "outname=s"=> \my $outname,

--- a/rp_bin/tarse_navi2
+++ b/rp_bin/tarse_navi2
@@ -29,7 +29,7 @@ my $qloc = &trans("queue");
 my $hmloc = &trans("hmloc");
 my $loloc = &trans("loloc");
 my $email = &trans("email");
-my $serial = &trans("serial") || 0;
+my $serial = &trans("serial");
 
 
 


### PR DESCRIPTION
Have all scripts run in serial mode if serial is set in the config file. 

Unfortunately this change means that serial  needs to be added to existing config files.