### PR TITLE
Use tabix when splitting imputation server vcfs

### DIFF
--- a/rp_bin/Ricopili/Version.pm
+++ b/rp_bin/Ricopili/Version.pm
@@ -16,7 +16,7 @@ our ($rp_header, $rp_version);
 
 
 
-$rp_version = "2019_Feb_18.001" ;
+$rp_version = "2019_Feb_20.001" ;
 
 
 my $rp_logo = <<'END_TXT';

--- a/rp_bin/impute_dirsub
+++ b/rp_bin/impute_dirsub
@@ -3743,6 +3743,16 @@ if ($impdeploy_done == 0) {
 			exit;
 		    }
 		}
+
+		# check for vcf index files (csi or tbi)
+		unless (-e "$vcf_file.csi" || -e "$vcf_file.tbi") {
+			print "------------------------------------------------------------------------------------------------------------\n";
+			print "Error: $vcf_file index (csi or tbi) not found\n";
+			print "Please copy from imputation server output or generate in $subdir_in with \"tabix -p vcf\"\n";
+			print "------------------------------------------------------------------------------------------------------------\n";
+			exit;
+		}
+
 		my $keep_txt = "";
 		$keep_txt = "--keepvcf" if ($noclean);
 		

--- a/rp_bin/vcf2dos
+++ b/rp_bin/vcf2dos
@@ -15,6 +15,7 @@ use Ricopili::Utils qw(trans);
 
 use lib $ENV{rp_perlpackages};
 use Compress::Zlib ;
+use IO::Zlib;
 #use Time;
 
 
@@ -235,7 +236,18 @@ if ($legend_sw == 1) {
 ## translate vcf file
 ##############################################
 
-my $igz = gzopen("$vcf_file", "rb")  or die "Cannot open file $vcf_file: $gzerrno\n" ;
+# check for vcf index file and use with tabix if present
+# if not, read entire file as before
+my $vcf_has_index = -e "$vcf_file.csi" || -e "$vcf_file.tbi";
+
+if ($vcf_has_index) {
+  my $tabix = trans("tabixloc") . "/tabix";
+  my $tabix_cmd = "$tabix -h $vcf_file $chr:$start_loc-$end_loc";
+  die $!."$tabix_cmd" unless open VCF, "-|", "$tabix_cmd";
+} else {
+  die $!."$vcf_file" unless tie *VCF, "IO::Zlib", "$vcf_file", "rb";
+}
+
 my $ovgz = gzopen("$outvcf", "wb")  or die "Cannot open file $outvcf: $gzerrno\n" ;
 my $odgz = gzopen("$outdos", "wb")  or die "Cannot open file $outdos: $gzerrno\n" ;
 
@@ -248,7 +260,8 @@ die $!."$outmap" unless open MAP, "> $outmap";
 print "translating $vcf_file into $outvcf and $outdos\n";
 
 my $nwarnings=0;
-while ($igz->gzreadline(my $line)){
+
+while (my $line = <VCF>){
     chomp($line);
     my @cells = @{&split_line_ref_tab(\$line)};
     
@@ -383,7 +396,7 @@ while ($igz->gzreadline(my $line)){
     
 }
 
-$igz->gzclose();
+close VCF;
 $ovgz->gzclose();
 $odgz->gzclose();
 close MAP;


### PR DESCRIPTION
As discussed in emails with Stephan. Using the new --deploy option for pre- and postprocessing imputation server files, I found the conversion from chromosomal vcfs to dosage chunks too slow in some cases.

I updated the scripts to use tabix for deployed imputation files with indices, which improved performance substantially (now my problematic chunks finish before the cluster kills them).

The logic I wrote stops with an error if using --deploy and there are no index files (I think both Sanger and Michigan provide them?), but for other uses of vcf2dos (i.e. in-house imputation), the script should proceed by reading the full file if there is no index.
